### PR TITLE
Add test for form submission and check for display on DOM

### DIFF
--- a/cypress/integration/main_test.js
+++ b/cypress/integration/main_test.js
@@ -27,4 +27,15 @@ describe('Main', () => {
     .get('.title-response').type('Photo 3').should('have.value', 'Photo 3')
     .get('.url-response').type('https://images.unsplash.com/fakeurl').should('have.value', 'https://images.unsplash.com/fakeurl')
   })
+
+  it('As a user, when I type I subit the form, it should be displayed on the DOM', () => {
+      cy.intercept('GET', 'http://localhost:3000/api/v1/*', {
+    statusCode: 200
+  }).as('matchedUrl')
+  cy.visit('http://localhost:3000/')
+    .get('.title-response').type('Newest One')
+    .get('.url-response').type('https://images.unsplash.com/photo-1531898418865-480b7090470f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=934&q=33')
+    .get('.shorten-button').click()
+    .get('.short-url').last().should('contain', 'http://localhost:3001/useshorturl/')
+  })
 })


### PR DESCRIPTION
I had trouble with Cypress identifying the most recent short URL. So, I cut off the number at the end of the .should('contain', URL). This way I could check that a short URL was being displayed for the new form entry, but the number was always increasing by one, which is why I removed that part of the url from the test.